### PR TITLE
macOS support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 *.o
+*.dylib*
 *.so*
 *.d
+*.pod
 *~
 
 mrgingham
@@ -9,6 +11,7 @@ test-dump-chessboard-corners
 test-dump-blobs
 mrgingham-observe-pixel-uncertainty.pod
 mrgingham-from-image
+mrgingham.usage.h
 
 core
 
@@ -23,5 +26,8 @@ debian/libmrgingham-dev/
 debian/libmrgingham1/
 debian/tmp/
 test/data/
+
+mrbuild
+mrbuild/
 
 *.docstring.h

--- a/mrgingham-from-image.cc
+++ b/mrgingham-from-image.cc
@@ -10,6 +10,11 @@
 
 using namespace mrgingham;
 
+#ifndef GLOB_TILDE_CHECK
+// GLOB_TILDE_CHECK doesn't exist on macOS, but GLOB_TILDE will usually work instead.
+#define GLOB_TILDE_CHECK GLOB_TILDE
+#endif
+
 struct mrgingham_thread_context_t
 {
     const glob_t* _glob;

--- a/mrgingham-rotate-corners
+++ b/mrgingham-rotate-corners
@@ -52,6 +52,11 @@ rotation option are passed through unrotated.
 --gridn defaults to 10, for a 10x10 board
 "
 
+if [ $(uname -s) = "Darwin" ] && [ $(getopt -V) = "--" ] && command -v brew > /dev/null 2>&1; then
+  # Brew does not add GNU getopt to PATH by default, so it is added here if BSD getopt is detected
+  PATH="$(brew --prefix)/opt/gnu-getopt/bin:$PATH"
+fi
+
 ARGS=$(getopt -n $0 -l help,gridn:,90:,180:,270: -o "h" -- "$@")
 
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
This fixes a few incompatibilities with macOS. `GLOB_TILDE_CHECK` doesn't exist, so `GLOB_TILDE` is used as a best-effort fallback. The `getopt` command available in macOS by default is a very basic BSD version that does not support long options. If it is detected, `mrgingham-rotate-corners` will try and find `gnu-getopt` from `brew` instead. (MacPorts puts it on `PATH` by default during installation, so a `brew` fallback is probably the only one necessary.) The multidimensional broadcast in `mrgingham_pywrap.c` relied on nested functions which is a GCC-specific compiler extension, so I flattened it into a `while` loop to be compatible with Clang.

With `opencv` and `gnu-getopt` installed through brew, `vnlog` cloned locally and `mrbuild` symlinked in, I was able to run the following to pass all tests:
```
vnlog (macOS-support) % CPPFLAGS="-I$(brew --prefix)/include" LDFLAGS="-L$(brew --prefix)/lib" make
vnlog (macOS-support) % PATH="../vnlog:$PATH" make test
```